### PR TITLE
[WIP] Feature/product demodata

### DIFF
--- a/src/Pyz/Zed/Product/Business/Internal/DemoData/ProductDataInstall.php
+++ b/src/Pyz/Zed/Product/Business/Internal/DemoData/ProductDataInstall.php
@@ -78,14 +78,6 @@ class ProductDataInstall implements DemoDataInstallInterface
     protected function createAttributes()
     {
         /**
-         * INSERT INTO `pac_attribute_type` (`type_id`, `name`, `parent_type_id`, `input_representation`)
-            VALUES
-            (1, 'string', NULL, 'input'),
-            (2, 'number', NULL, 'number'),
-            (3, 'boolean', NULL, 'checkbox'),
-            (4, 'enum', NULL, 'select'),
-            (5, 'array', 4, 'list');
-         *
          * INSERT INTO `pac_attributes_metadata` (`attribute_id`, `key`, `is_editable`, `type_id`)
         VALUES
         (1, 'name', 1, 4),


### PR DESCRIPTION
Feature um Agenturen ein schnelleres Shop-Setup zu ermöglichen indem die Produktdaten bereits in die DB importiert werden (ohne Umweg über Zed-GUI).

Ähnliche Installer brauchen wir noch für:
- [x] Kategorien
- [x] Produktdaten
- [x] Zahlarten aktivieren (nur direct debit)
- [x] Produktattribute Metadata Tabelle befüllen
- [x] Produkattribute auf Suchfelder mappen
