### PR TITLE
added workaround bash for installing salt-minion before provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,6 +54,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   if Dir.exists?(PILLAR_DIRECTORY) && Dir.exists?(SALT_DIRECTORY)
     config.vm.synced_folder SALT_DIRECTORY,   "/srv/salt/"
     config.vm.synced_folder PILLAR_DIRECTORY, "/srv/pillar/"
+    config.vm.provision "shell", path: "bash/script.sh"
     config.vm.provision :salt do |salt|
       salt.minion_config = "salt/minion"
       salt.run_highstate = true

--- a/bash/script.sh
+++ b/bash/script.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+sudo echo "deb http://debian.saltstack.com/debian wheezy-saltstack main" >> /etc/apt/sources.list.d/saltstack.list
+wget -q -O- "http://debian.saltstack.com/debian-salt-team-joehealy.gpg.key" | sudo apt-key add -
+sudo apt-get update
+sudo apt-get -y install salt-common salt-minion


### PR DESCRIPTION
I needed to do this apt-get install of the salt minion because if not provisioning was not starting
