### PR TITLE
Renamed getExternalDependency to getInjectedDependency

### DIFF
--- a/src/Pyz/Zed/Glossary/Business/GlossaryDependencyContainer.php
+++ b/src/Pyz/Zed/Glossary/Business/GlossaryDependencyContainer.php
@@ -17,7 +17,7 @@ class GlossaryDependencyContainer extends SprykerGlossaryDependencyContainer
     public function createDemoDataInstaller(LoggerInterface $messenger)
     {
         $installers = [
-            $this->getDependency(GlossaryDependencyProvider::PLUGIN_YML_INSTALLER)
+            $this->getProvidedDependency(GlossaryDependencyProvider::PLUGIN_YML_INSTALLER)
         ];
         $installer = $this->getFactory()->createInternalDemoDataGlossaryInstall($installers);
         $installer->setMessenger($messenger);


### PR DESCRIPTION
Renamed getExternalDependency to getInjectedDependency because the dependencies are sometimes also internal e.g. plugins

Before i tried to rename it to getDependency and thought to have a getDependency method inside the DependencyContainer would be confusing
- [X] Licence checked
- [X] Integration check passed
- [ ] Documentation

Reviewed by:
Ticket Numbers:
Sub PR's: https://github.com/spryker/spryker/pull/97
