### PR TITLE
DEM-27-All Products and Categories on Homepage should be clickable

### DIFF
--- a/src/Pyz/Yves/Application/Theme/demoshop/layout/partials/main-nav.twig
+++ b/src/Pyz/Yves/Application/Theme/demoshop/layout/partials/main-nav.twig
@@ -19,7 +19,7 @@
     <section class="main-nav__specials">
         <h1 class="main-nav__heading">Ein Blick lohnt sich</h1>
         <ul class="main-nav__special-list">
-            {% include "@application/layout/partials/main-nav-button.twig" with {name:"Sale", url:"catalog.html?extras=sale", imageUrl:"/images/nav/sale.jpg"} %}
+            {% include "@application/layout/partials/main-nav-button.twig" with {name:"Sale", url:"/wilde-tiere?extras=sale", imageUrl:"/images/nav/sale.jpg"} %}
         </ul>
     </section>
 </nav>

--- a/src/Pyz/Zed/Glossary/File/initial_translation.yml
+++ b/src/Pyz/Zed/Glossary/File/initial_translation.yml
@@ -61,7 +61,7 @@ keys:
       de_DE: '/images/homepage/dragon.jpg'
   page.home.featured.top-right.second.url:
     translations:
-      de_DE: ''
+      de_DE: '/wilde-tiere'
 
   page.home.featured.bottom-left.top.width:
     translations:
@@ -74,7 +74,7 @@ keys:
       de_DE: 'Wald und Wiese'
   page.home.featured.bottom-left.top.category:
     translations:
-      de_DE: ''
+      de_DE: '/wald-und-wiese'
   page.home.featured.bottom-left.top.img:
     translations:
       de_DE: '/images/homepage/teaser-waldwiese.jpg'
@@ -93,7 +93,7 @@ keys:
       de_DE: 'Meere'
   page.home.featured.bottom-left.bottom.category:
     translations:
-      de_DE: ''
+      de_DE: '/meere'
   page.home.featured.bottom-left.bottom.img:
     translations:
       de_DE: '/images/homepage/sea.jpg'
@@ -118,7 +118,7 @@ keys:
       de_DE: '/images/homepage/ferkel.jpg'
   page.home.featured.bottom-right.left.url:
     translations:
-      de_DE: '/ferkel'
+      de_DE: '/ferkel,-stehend'
 
   page.home.featured.bottom-right.right.width:
     translations:


### PR DESCRIPTION
This bugfix fixes the broken links on the demo shop homepage.
Changes to the initial_translation.yml are going to be updated in redis after deleting the mysql database and installing the demo data again.
mysqladmin -u development -pmate20mg drop DE_development_zed
vendor/bin/console setup:install
vendor/bin/console setup:install-demo-data
vendor/bin/console frontend-exporter:export-search
vendor/bin/console frontend-exporter:export-key-value
- [x] Licence checked
- [x] Integration check passed
- [ ] Documentation

Reviewed by: 
Ticket Numbers:
Sub PR's:
