### PR TITLE
fix class name case to match the filename

### DIFF
--- a/src/Pyz/Zed/ProductOption/Business/Internal/DemoData/Importer/Transformer/XMLProductTransformer.php
+++ b/src/Pyz/Zed/ProductOption/Business/Internal/DemoData/Importer/Transformer/XMLProductTransformer.php
@@ -10,7 +10,7 @@ use Pyz\Zed\ProductOption\Business\Internal\DemoData\Importer\Node\ProductOption
 use Pyz\Zed\ProductOption\Business\Internal\DemoData\Importer\Node\ProductOptionValue;
 use Pyz\Zed\ProductOption\Business\Internal\DemoData\Importer\Node\ProductOptionValueConstraint;
 
-class XmlProductTransformer implements XmlTransformerInterface
+class XMLProductTransformer implements XMLTransformerInterface
 {
 
     /**


### PR DESCRIPTION
The classname and filename don't match on systems that care about case.
- [x] Licence checked
- [x] Integration check passed
- [ ] Documentation

Reviewed by: 
Ticket Numbers:
Sub PR's:
