### PR TITLE
use correct bundle name to request facade

### DIFF
--- a/src/Pyz/Zed/ProductOption/Communication/ProductDependencyContainer.php
+++ b/src/Pyz/Zed/ProductOption/Communication/ProductDependencyContainer.php
@@ -13,7 +13,7 @@ class ProductOptionDependencyContainer extends SprykerProductOptionDependencyCon
      */
     public function getInstallerFacade()
     {
-        return $this->getLocator()->productOptions()->facade();
+        return $this->getLocator()->productOption()->facade();
     }
 
 }


### PR DESCRIPTION
The facade is ProductOptionFacade, not ProductOptionsFacade.
- [x] Licence checked
- [x] Integration check passed
- [ ] Documentation

Reviewed by:
Ticket Numbers: https://spryker.atlassian.net/browse/CD-134
Sub PR's:
