### PR TITLE
Renamed AbstractDependencyContainer

### DIFF
--- a/src/Pyz/Yves/Checkout/Communication/CheckoutDependencyContainer.php
+++ b/src/Pyz/Yves/Checkout/Communication/CheckoutDependencyContainer.php
@@ -2,12 +2,12 @@
 
 namespace Pyz\Yves\Checkout\Communication;
 
-use SprykerEngine\Yves\Kernel\Communication\AbstractDependencyContainer;
+use SprykerEngine\Yves\Kernel\Communication\AbstractCommunicationDependencyContainer;
 use SprykerFeature\Client\Cart\Service\CartClientInterface;
 use SprykerFeature\Client\Checkout\Service\CheckoutClient;
 use Pyz\Yves\Checkout\Communication\Form\Checkout;
 
-class CheckoutDependencyContainer extends AbstractDependencyContainer
+class CheckoutDependencyContainer extends AbstractCommunicationDependencyContainer
 {
     /**
      * @return CheckoutClient


### PR DESCRIPTION
Renamed AbstractDependencyContainer to Abstract_Layer_DependencyContainer
- [X] Licence checked
- [X] Integration check passed
- [X] Documentation

Ticket Numbers: https://spryker.atlassian.net/browse/CD-141
Sub PR's: https://github.com/spryker/spryker/pull/158
Reviewed by:
Tests executed by:
Develop ready approved by:
