### PR TITLE
Moved getLocator method to core

### DIFF
--- a/src/Pyz/Yves/Application/Communication/YvesBootstrap.php
+++ b/src/Pyz/Yves/Application/Communication/YvesBootstrap.php
@@ -150,16 +150,6 @@ class YvesBootstrap extends SprykerYvesBootstrap
     /**
      * @param Application $app
      *
-     * @return AutoCompletion|\Generated\Client\Ide\AutoCompletion
-     */
-    protected function getLocator(Application $app)
-    {
-        return $app['locator'];
-    }
-
-    /**
-     * @param Application $app
-     *
      * @return array
      */
     protected function globalTemplateVariables(Application $app)


### PR DESCRIPTION
IdeAutocompletion files had method tags for abstract classes. I added a check if current file is instantiable.

Method tags for abstract classes are no longer generated

Moved getLocator to core
- [X] Licence checked
- [X] Integration check passed
- [ ] Documentation

Ticket Numbers: https://spryker.atlassian.net/browse/CD-215
Sub PR's: https://github.com/spryker/spryker/pull/185
Reviewed by:
Tests executed by:
Develop ready approved by:
