### PR TITLE
CD-287 refactored cart client to take only TransferInterface as argument

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "require": {
-    "spryker/spryker": "dev-develop",
+    "spryker/spryker": "dev-refactor/CD-287-Use-TransferObject-instead-of-parameter",
 
     "psr/log": "~1.0",
     "propel/propel": "~2.0@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ed3cd16260d448e6941cd049ff503fce",
+    "hash": "e7c6da976715aea5912dff9a24a1ff7b",
     "packages": [
         {
             "name": "digital-canvas/zend-framework",
@@ -708,11 +708,11 @@
         },
         {
             "name": "spryker/spryker",
-            "version": "dev-develop",
+            "version": "dev-refactor/CD-287-Use-TransferObject-instead-of-parameter",
             "source": {
                 "type": "git",
                 "url": "git@github.com:spryker/spryker.git",
-                "reference": "f4a736559868b8e475f5e589468e99938819aacb"
+                "reference": "dae6dd7eb07a0b808707ddd89384e3f2a07cf615"
             },
             "require": {
                 "digital-canvas/zend-framework": ">=1.12.2",
@@ -845,7 +845,7 @@
                     "SprykerFeature\\Shared\\Library": "Bundles/Library/src/"
                 }
             },
-            "time": "2015-07-20 09:19:59"
+            "time": "2015-07-20 12:51:49"
         },
         {
             "name": "symfony-cmf/routing",

--- a/src/Pyz/Yves/Cart/Communication/Controller/AjaxController.php
+++ b/src/Pyz/Yves/Cart/Communication/Controller/AjaxController.php
@@ -2,6 +2,7 @@
 
 namespace Pyz\Yves\Cart\Communication\Controller;
 
+use Generated\Shared\Transfer\CartItemTransfer;
 use Pyz\Yves\Cart\Communication\Plugin\CartControllerProvider;
 use SprykerEngine\Yves\Application\Communication\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -36,7 +37,11 @@ class AjaxController extends AbstractController
     public function addAction($sku, $quantity)
     {
         $cartClient = $this->getLocator()->cart()->client();
-        $cartClient->addItem($sku, $quantity);
+        $cartItemTransfer = new CartItemTransfer();
+        $cartItemTransfer->setId($sku)
+            ->setQuantity($quantity)
+        ;
+        $cartClient->addItem($cartItemTransfer);
 
         return $this->redirectResponseInternal(CartControllerProvider::ROUTE_CART_OVERLAY);
     }
@@ -49,7 +54,10 @@ class AjaxController extends AbstractController
     public function removeAction($sku)
     {
         $cartClient = $this->getLocator()->cart()->client();
-        $cartClient->removeItem($sku);
+        $cartItemTransfer = new CartItemTransfer();
+        $cartItemTransfer->setId($sku);
+
+        $cartClient->removeItem($cartItemTransfer);
 
         return $this->redirectResponseInternal(CartControllerProvider::ROUTE_CART_OVERLAY);
     }
@@ -62,7 +70,10 @@ class AjaxController extends AbstractController
     public function increaseAction($sku)
     {
         $cartClient = $this->getLocator()->cart()->client();
-        $cartClient->increaseItemQuantity($sku);
+        $cartItemTransfer = new CartItemTransfer();
+        $cartItemTransfer->setId($sku);
+
+        $cartClient->increaseItemQuantity($cartItemTransfer);
 
         return $this->redirectResponseInternal(CartControllerProvider::ROUTE_CART_OVERLAY);
     }
@@ -75,7 +86,10 @@ class AjaxController extends AbstractController
     public function decreaseAction($sku)
     {
         $cartClient = $this->getLocator()->cart()->client();
-        $cartClient->decreaseItemQuantity($sku);
+        $cartItemTransfer = new CartItemTransfer();
+        $cartItemTransfer->setId($sku);
+
+        $cartClient->decreaseItemQuantity($cartItemTransfer);
 
         return $this->redirectResponseInternal(CartControllerProvider::ROUTE_CART_OVERLAY);
     }

--- a/src/Pyz/Yves/Cart/Communication/Controller/CartController.php
+++ b/src/Pyz/Yves/Cart/Communication/Controller/CartController.php
@@ -2,6 +2,7 @@
 
 namespace Pyz\Yves\Cart\Communication\Controller;
 
+use Generated\Shared\Transfer\CartItemTransfer;
 use SprykerEngine\Yves\Application\Communication\Controller\AbstractController;
 use Pyz\Yves\Cart\Communication\Plugin\CartControllerProvider;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -32,7 +33,11 @@ class CartController extends AbstractController
     public function addAction($sku, $quantity)
     {
         $cartClient = $this->getLocator()->cart()->client();
-        $cartClient->addItem($sku, $quantity);
+        $cartItemTransfer = new CartItemTransfer();
+        $cartItemTransfer->setId($sku)
+            ->setQuantity($quantity)
+        ;
+        $cartClient->addItem($cartItemTransfer);
 
         return $this->redirectResponseInternal(CartControllerProvider::ROUTE_CART);
     }
@@ -45,7 +50,10 @@ class CartController extends AbstractController
     public function removeAction($sku)
     {
         $cartClient = $this->getLocator()->cart()->client();
-        $cartClient->removeItem($sku);
+        $cartItemTransfer = new CartItemTransfer();
+        $cartItemTransfer->setId($sku);
+
+        $cartClient->removeItem($cartItemTransfer);
 
         return $this->redirectResponseInternal(CartControllerProvider::ROUTE_CART);
     }
@@ -59,7 +67,9 @@ class CartController extends AbstractController
     public function changeAction($sku, $quantity)
     {
         $cartClient = $this->getLocator()->cart()->client();
-        $cartClient->changeItemQuantity($sku, $quantity);
+        $cartItemTransfer = new CartItemTransfer();
+        $cartItemTransfer->setId($sku);
+        $cartClient->changeItemQuantity($cartItemTransfer, $quantity);
 
         return $this->redirectResponseInternal(CartControllerProvider::ROUTE_CART);
     }


### PR DESCRIPTION
Refactored CartClient to use TransferInterface as argument. This makes it easier for projects to change the behaviour of the Cart 
- [X] Licence checked
- [X] Integration check passed
- [ ] Run CS-Fixer
- [ ] Documentation

Ticket Numbers: https://spryker.atlassian.net/browse/CD-287
Sub PR's: https://github.com/spryker/spryker/pull/204
Reviewed by:
Tests executed by:
Develop ready approved by:
