### PR TITLE
CD-356 ProductOption Sales integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "require": {
-    "spryker/spryker": "dev-develop",
+    "spryker/spryker": "dev-feature/CD-356-product-option-sales-integration",
 
     "psr/log": "~1.0",
     "propel/propel": "~2.0@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ed3cd16260d448e6941cd049ff503fce",
+    "hash": "876ed9534471b27eef719258352eb6e0",
     "packages": [
         {
             "name": "digital-canvas/zend-framework",
@@ -708,11 +708,11 @@
         },
         {
             "name": "spryker/spryker",
-            "version": "dev-develop",
+            "version": "dev-feature/CD-356-product-option-sales-integration",
             "source": {
                 "type": "git",
                 "url": "git@github.com:spryker/spryker.git",
-                "reference": "511d39fbad221b7f9664306664795497347dc926"
+                "reference": "36a9c2b9001052e3e31ea23a045e5946258d554e"
             },
             "require": {
                 "digital-canvas/zend-framework": ">=1.12.2",
@@ -845,7 +845,7 @@
                     "SprykerFeature\\Shared\\Library": "Bundles/Library/src/"
                 }
             },
-            "time": "2015-08-04 11:29:26"
+            "time": "2015-08-04 21:00:58"
         },
         {
             "name": "symfony-cmf/routing",


### PR DESCRIPTION
This PR is for ProductOption Sales integration. After checking out an order with product options, a snapshot of product option related data is saved to the database. Use the corresponding [core branch](https://github.com/spryker/spryker/tree/feature%2FCD-356-product-option-sales-integration) to test this.
- [X] Licence checked
- [X] Integration check passed
- [X] Documentation

Reviewed by: 
Ticket Numbers: https://spryker.atlassian.net/browse/CD-356
Sub PR's:
Tests executed by:
Develop ready approved by:
