### PR TITLE
CD-368 SetupInstall commands now configurable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "require": {
-    "spryker/spryker": "dev-develop",
+    "spryker/spryker": "dev-feature/CD-368-Make-depending-commands-configurable-for-setup-install",
 
     "psr/log": "~1.0",
     "propel/propel": "~2.0@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ed3cd16260d448e6941cd049ff503fce",
+    "hash": "fa5979fda5a13a731329f7430de3305c",
     "packages": [
         {
             "name": "digital-canvas/zend-framework",
@@ -708,11 +708,11 @@
         },
         {
             "name": "spryker/spryker",
-            "version": "dev-develop",
+            "version": "dev-feature/CD-368-Make-depending-commands-configurable-for-setup-install",
             "source": {
                 "type": "git",
                 "url": "git@github.com:spryker/spryker.git",
-                "reference": "8ff97b53e2d953581054cf162c09742847d8651e"
+                "reference": "beef49687065da3cb35aca027d57840211e0c300"
             },
             "require": {
                 "digital-canvas/zend-framework": ">=1.12.2",
@@ -845,7 +845,7 @@
                     "SprykerFeature\\Shared\\Library": "Bundles/Library/src/"
                 }
             },
-            "time": "2015-08-11 13:48:36"
+            "time": "2015-08-12 07:23:45"
         },
         {
             "name": "symfony-cmf/routing",


### PR DESCRIPTION
SetupInstall commands are now configurable with SetupConfig
- [X] License checked
- [X] Integration check passed
- [ ] Run CS-Fixer
- [ ] Documentation

Ticket Numbers: https://spryker.atlassian.net/browse/CD-368
Sub PR's: https://github.com/spryker/spryker/pull/283
Reviewed by:
Develop ready approved by:
