### PR TITLE
Correct Mapping between Category and Node

### DIFF
--- a/src/Pyz/Zed/Collector/Business/Storage/ProductCollector.php
+++ b/src/Pyz/Zed/Collector/Business/Storage/ProductCollector.php
@@ -322,12 +322,12 @@ class ProductCollector extends AbstractPropelCollectorPlugin
         );
         $baseQuery->addJoin(
             SpyProductCategoryTableMap::COL_FK_CATEGORY,
-            SpyCategoryNodeTableMap::COL_ID_CATEGORY_NODE,
+            SpyCategoryAttributeTableMap::COL_FK_CATEGORY,
             Criteria::INNER_JOIN
         );
         $baseQuery->addJoin(
+            SpyProductCategoryTableMap::COL_FK_CATEGORY,
             SpyCategoryNodeTableMap::COL_FK_CATEGORY,
-            SpyCategoryAttributeTableMap::COL_FK_CATEGORY,
             Criteria::INNER_JOIN
         );
 


### PR DESCRIPTION
This is a little bugfix, correcting an obviously wrong mapping between category_id and node_id.
​
- [X] License checked
- [ ] Integration check passed
- [ ] Run CS-Fixer
- [ ] Documentation
- [ ] Backward compatible breaks
- [ ] Deprecations
  ​
  Ticket Numbers:
  Sub PR's:
  Reviewed by: @anusch-athari
  Develop ready approved by:
