### PR TITLE
Fixes usage of renamed method in checkout controller

### DIFF
--- a/src/Pyz/Yves/Checkout/Communication/Controller/CheckoutController.php
+++ b/src/Pyz/Yves/Checkout/Communication/Controller/CheckoutController.php
@@ -44,7 +44,7 @@ class CheckoutController extends AbstractController
         ;
         $checkoutForm = $container->createCheckoutForm($shipmentTransfer);
         $checkoutTransfer = new CheckoutRequestTransfer();
-        $checkoutTransfer->setGuest(true); // @TODO: only for Development
+        $checkoutTransfer->setIsGuest(true); // @TODO: only for Development
 
         $form = $this->createForm($checkoutForm, $checkoutTransfer);
 


### PR DESCRIPTION
The method ChecktouRequestTransfer::setGuest() got renamed to setIsGuest() but its usage
in the cart didn't get aligned.
