### PR TITLE
Update circle config to use the right constant

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,7 @@ test:
   pre:
     - >
       if [ -n "${RUN_SPRYKER_BUILD}" ]; then
-        cd vendor/spryker/spryker && git checkout origin/${BRANCH_PARENT}
+        cd vendor/spryker/spryker && git checkout origin/${BRANCH}
       fi
   override:
 #    - phpcpd . --exclude="vendor" --exclude="config" --exclude="src/Generated" -n


### PR DESCRIPTION
Fixed use of wrong constant in circle config
- [X] License checked
- [X] Integration check passed
- [ ] Run CS-Fixer
- [ ] Documentation
- [ ] Backward compatible breaks
- [ ] Deprecations
  ​
  Ticket Numbers:
  Sub PR's:
  Reviewed by: @anusch-athari
  Develop ready approved by:
