### PR TITLE
CD-527 make cookie name configurable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "require": {
-    "spryker/spryker": "dev-develop",
+    "spryker/spryker": "dev-refactor/CD-527-Rename-cookie-Zed-ACL",
 
     "psr/log": "~1.0",
     "propel/propel": "~2.0@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "5c26ddc662de80bb8e4f4cd8016e3d44",
+    "hash": "651e1a80d0f2b74423f91f21e560b3d4",
     "packages": [
         {
             "name": "digital-canvas/zend-framework",
@@ -703,11 +703,11 @@
         },
         {
             "name": "spryker/spryker",
-            "version": "dev-develop",
+            "version": "dev-refactor/CD-527-Rename-cookie-Zed-ACL",
             "source": {
                 "type": "git",
                 "url": "git@github.com:spryker/spryker.git",
-                "reference": "a0456d0bba83b2a2d011e36853fdd1bd2e364672"
+                "reference": "97132becefb0144f5b6ba22432ef9eb014abc785"
             },
             "require": {
                 "digital-canvas/zend-framework": ">=1.12.2"
@@ -796,7 +796,7 @@
                     "SprykerFeature\\Shared\\Library": "Bundles/Library/src/"
                 }
             },
-            "time": "2015-10-09 10:58:56"
+            "time": "2015-10-09 11:26:43"
         },
         {
             "name": "symfony-cmf/routing",

--- a/config/Shared/config_default.php
+++ b/config/Shared/config_default.php
@@ -80,6 +80,7 @@ $config[SystemConfig::YVES_STORAGE_SESSION_TIME_TO_LIVE] = SessionConfig::SESSIO
 $config[SystemConfig::YVES_STORAGE_SESSION_FILE_PATH] = session_save_path();
 
 $config[SystemConfig::ZED_STORAGE_SESSION_TIME_TO_LIVE] = SessionConfig::SESSION_LIFETIME_30_DAYS;
+$config[SystemConfig::ZED_STORAGE_SESSION_COOKIE_NAME] = 'zed_session';
 $config[SystemConfig::ZED_STORAGE_SESSION_FILE_PATH] = session_save_path();
 $config[SystemConfig::ZED_SESSION_SAVE_HANDLER] = null;
 


### PR DESCRIPTION
Make session cookie name configurable for zed 
​
- [X] License checked
- [X] Integration check passed
- [X] Run CS-Fixer
- [ ] Documentation
- [ ] Backward compatible breaks
- [ ] Deprecations

Ticket Numbers: https://spryker.atlassian.net/browse/CD-527
Sub PR's: https://github.com/spryker/spryker/pull/507
Reviewed by:
Develop ready approved by:
