### PR TITLE
Cd-528 update composer, add session.test true to config_default-devel…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "require": {
-    "spryker/spryker": "dev-develop",
+    "spryker/spryker": "dev-feature/CD-528-Redirect-after-login",
 
     "psr/log": "~1.0",
     "propel/propel": "~2.0@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "5c26ddc662de80bb8e4f4cd8016e3d44",
+    "hash": "e80ec6ecff86b566815368019c4daa1e",
     "packages": [
         {
             "name": "digital-canvas/zend-framework",
@@ -703,11 +703,11 @@
         },
         {
             "name": "spryker/spryker",
-            "version": "dev-develop",
+            "version": "dev-feature/CD-528-Redirect-after-login",
             "source": {
                 "type": "git",
                 "url": "git@github.com:spryker/spryker.git",
-                "reference": "a6831d6c4e5bdcd58b83e2b942992ea0288e24b2"
+                "reference": "ca30d3e689d550c615a49d636d66cf634ad42b0c"
             },
             "require": {
                 "digital-canvas/zend-framework": ">=1.12.2"
@@ -796,7 +796,7 @@
                     "SprykerFeature\\Shared\\Library": "Bundles/Library/src/"
                 }
             },
-            "time": "2015-10-09 12:30:59"
+            "time": "2015-10-12 11:47:03"
         },
         {
             "name": "symfony-cmf/routing",

--- a/config/Shared/config_default-development.php
+++ b/config/Shared/config_default-development.php
@@ -38,3 +38,4 @@ $config[AclConfig::ACL_USER_RULE_WHITELIST][] = [
 
 $config[SystemConfig::PROPEL_DEBUG] = true;
 $config[ApplicationConfig::SHOW_SYMFONY_TOOLBAR] = true;
+$config[SessionConfig::SESSION_IS_TEST] = true;

--- a/src/Pyz/Zed/Application/Communication/ZedBootstrap.php
+++ b/src/Pyz/Zed/Application/Communication/ZedBootstrap.php
@@ -106,6 +106,7 @@ class ZedBootstrap extends Bootstrap
             new SilexSessionServiceProvider(),
             $sessionServiceProvider,
             new PropelServiceProvider(),
+            $locator->auth()->pluginServiceProviderRedirectAfterLoginProvider(),
             $locator->auth()->pluginBootstrapAuthBootstrapProvider(),
             new RequestServiceProvider(),
             new SslServiceProvider(),


### PR DESCRIPTION
Add RedirectAfterLoginProvider to Bootstrap, add session.test = true in config_default-development
- [X] License checked
- [X] Integration check passed
- [X] Run CS-Fixer
- [ ] Documentation
- [ ] Backward compatible breaks
- [ ] Deprecations

Ticket Numbers: https://spryker.atlassian.net/browse/CD-528
Sub PR's: https://github.com/spryker/spryker/pull/510
Reviewed by:
Develop ready approved by:
