### PR TITLE
CD-584 fixed problem during setup install: Task 'all' is not in your …

### DIFF
--- a/gulp/zed.js
+++ b/gulp/zed.js
@@ -174,6 +174,10 @@ gulp.task('assets', function() {
     console.log('{0} files found\n'.format(assets.length).yellow);
 });
 
+gulp.task('all', function() {
+    gulp.start('dist');
+});
+
 gulp.task('default', function() {
     gulp.start('dist');
 });


### PR DESCRIPTION
Fixes error during setup:install: Task 'all' is not in your gulpfile
- [x] License checked
- [ ] Integration check passed
- [ ] Run CS-Fixer
- [ ] Documentation
- [ ] Backward compatible breaks
- [ ] Deprecations

Ticket Numbers:
Sub PR's:
Reviewed by:
Develop ready approved by:
