### PR TITLE
Remove lumberjack logging for now.

### DIFF
--- a/config/Shared/config_default.php
+++ b/config/Shared/config_default.php
@@ -295,7 +295,8 @@ $config[LumberjackConfig::COLLECTORS]['YVES'] = [
     '\SprykerFeature\Client\Lumberjack\Service\YvesDataCollector',
 ];
 $config[LumberjackConfig::WRITERS]['YVES'] = [
-    '\SprykerEngine\Shared\Lumberjack\Model\Writer\File',
+    //FIXME: After hackaton we need to fix this for linux systems
+    //'\SprykerEngine\Shared\Lumberjack\Model\Writer\File',
 ];
 
 $config[LumberjackConfig::COLLECTORS]['ZED'] = [
@@ -304,7 +305,8 @@ $config[LumberjackConfig::COLLECTORS]['ZED'] = [
     '\SprykerEngine\Shared\Lumberjack\Model\Collector\EnvironmentDataCollector',
 ];
 $config[LumberjackConfig::WRITERS]['ZED'] = [
-    '\SprykerEngine\Shared\Lumberjack\Model\Writer\File',
+    //FIXME: After hackaton we need to fix this for linux systems
+    //'\SprykerEngine\Shared\Lumberjack\Model\Writer\File',
 ];
 
 $config[LumberjackConfig::COLLECTOR_OPTIONS] = [


### PR DESCRIPTION
Right now everyone on linux would get

```
ErrorException - fopen(.../lumberjack.2015-11-10.1.log): failed to open stream: Permission denied
```

Even when redirecting the path to /tmp/ or sth.

//cc @slangwald 
- [x] License checked
- [ ] Integration check passed
- [ ] Run CS-Fixer
- [ ] Documentation
- [ ] Backward compatible breaks
- [ ] Deprecations

Ticket Numbers:
Sub PR's:
Reviewed by:
Develop ready approved by:
