### PR TITLE
SP-103 Fix incorrect category page display in firefox

### DIFF
--- a/static/assets/Yves/styles/layout/_catalog.scss
+++ b/static/assets/Yves/styles/layout/_catalog.scss
@@ -138,7 +138,7 @@
 }
 
 .catalog__products {
-  display: flex;
+  display: block;
   flex-wrap: wrap;
   transition: transform .5s;
   width: 100%;
@@ -208,6 +208,7 @@
 }
 
 .catalog__product {
+  float: left;
   position: relative;
   display: block;
   width: 100%;


### PR DESCRIPTION
It seems that firefox doesn't like display:flex
- [x] License checked
- [x] Integration check passed
- [x] Run CS-Fixer
- [ ] Documentation
- [ ] Backward compatible breaks
- [ ] Deprecations

Ticket Numbers: https://spryker.atlassian.net/browse/SP-103
Sub PR's:
Reviewed by:
Develop ready approved by:
