### PR TITLE
Fix glossary translation for url containing comma

### DIFF
--- a/src/Pyz/Zed/Glossary/File/initial_translation.yml
+++ b/src/Pyz/Zed/Glossary/File/initial_translation.yml
@@ -157,8 +157,8 @@ keys:
       en_US: '/images/homepage/pig.jpg'
   page.home.featured.bottom-right.left.url:
     translations:
-      de_DE: '/ferkel,-stehend'
-      en_US: '/pig,-standing'
+      de_DE: '/ferkel-stehend'
+      en_US: '/pig-standing'
 
   page.home.featured.bottom-right.right.width:
     translations:


### PR DESCRIPTION
Fix broken url translation
- [x] License checked
- [ ] Integration check passed
- [ ] Run CS-Fixer
- [ ] Documentation
- [ ] Backward compatible breaks
- [ ] Deprecations

Ticket Numbers:
Sub PR's:
Reviewed by:
Develop ready approved by:
