### PR TITLE
SP-167 made sure collectors properly set spy_touch_storage and spy_to…

### DIFF
--- a/src/Pyz/Zed/Collector/Business/Search/ProductCollector.php
+++ b/src/Pyz/Zed/Collector/Business/Search/ProductCollector.php
@@ -259,6 +259,10 @@ class ProductCollector extends AbstractPropelCollectorPlugin
             SpyCategoryNodeTableMap::COL_FK_CATEGORY,
             'category_id'
         );
+        $baseQuery->withColumn(
+            SpyTouchTableMap::COL_ID_TOUCH,
+            self::TOUCH_EXPORTER_ID
+        );
         $baseQuery->orderBy('depth', Criteria::DESC);
         $baseQuery->orderBy('descendant_id', Criteria::DESC);
         $baseQuery->groupBy('abstract_sku');
@@ -298,6 +302,8 @@ class ProductCollector extends AbstractPropelCollectorPlugin
                     'direct-parents' => explode(',', $productRawData['node_id']),
                     'all-parents' => explode(',', $productRawData['category_parent_ids']),
                 ];
+
+                $touchUpdaterSet->add($index, $resultSet[$index][self::TOUCH_EXPORTER_ID]);
             }
         }
 

--- a/src/Pyz/Zed/Collector/Business/Storage/CategoryNodeCollector.php
+++ b/src/Pyz/Zed/Collector/Business/Storage/CategoryNodeCollector.php
@@ -89,6 +89,10 @@ class CategoryNodeCollector extends AbstractPropelCollectorPlugin
             SpyCategoryNodeTableMap::COL_FK_CATEGORY,
             'category_id'
         );
+        $baseQuery->withColumn(
+            SpyTouchTableMap::COL_ID_TOUCH,
+            self::TOUCH_EXPORTER_ID
+        );
 
         $baseQuery->orderBy('depth', Criteria::DESC);
         $baseQuery->orderBy('descendant_id', Criteria::DESC);
@@ -111,6 +115,7 @@ class CategoryNodeCollector extends AbstractPropelCollectorPlugin
         foreach ($resultSet as $index => $categoryNode) {
             $categoryKey = $this->generateKey($categoryNode['node_id'], $locale->getLocaleName());
             $processedResultSet[$categoryKey] = $this->formatCategoryNode($categoryNode);
+            $touchUpdaterSet->add($categoryKey, $categoryNode[self::TOUCH_EXPORTER_ID]);
         }
 
         return $processedResultSet;

--- a/src/Pyz/Zed/Collector/Business/Storage/PageCollector.php
+++ b/src/Pyz/Zed/Collector/Business/Storage/PageCollector.php
@@ -70,6 +70,10 @@ class PageCollector extends AbstractPropelCollectorPlugin
         $baseQuery->withColumn(SpyCmsGlossaryKeyMappingTableMap::COL_PLACEHOLDER, 'placeholder');
         $baseQuery->withColumn(SpyCmsTemplateTableMap::COL_TEMPLATE_PATH, 'template_path');
         $baseQuery->withColumn(SpyGlossaryKeyTableMap::COL_KEY, 'translation_key');
+        $baseQuery->withColumn(
+            SpyTouchTableMap::COL_ID_TOUCH,
+            self::TOUCH_EXPORTER_ID
+        );
 
         return $baseQuery;
     }
@@ -94,6 +98,7 @@ class PageCollector extends AbstractPropelCollectorPlugin
             $processedResultSet[$pageKey]['template'] = $page['template_path'];
             $processedResultSet[$pageKey]['placeholders'] = isset($processedResultSet[$pageKey]['placeholders']) ? $processedResultSet[$pageKey]['placeholders'] : [];
             $processedResultSet[$pageKey]['placeholders'][$page['placeholder']] = $page['translation_key'];
+            $touchUpdaterSet->add($pageKey, $page[self::TOUCH_EXPORTER_ID]);
         }
 
         return $processedResultSet;

--- a/src/Pyz/Zed/Collector/Business/Storage/ProductCollector.php
+++ b/src/Pyz/Zed/Collector/Business/Storage/ProductCollector.php
@@ -351,6 +351,10 @@ class ProductCollector extends AbstractPropelCollectorPlugin
             SpyCategoryNodeTableMap::COL_FK_CATEGORY,
             'category_id'
         );
+        $baseQuery->withColumn(
+            SpyTouchTableMap::COL_ID_TOUCH,
+            self::TOUCH_EXPORTER_ID
+        );
         $baseQuery->orderBy('depth', Criteria::DESC);
         $baseQuery->orderBy('descendant_id', Criteria::DESC);
         $baseQuery->groupBy('abstract_sku');
@@ -440,6 +444,8 @@ class ProductCollector extends AbstractPropelCollectorPlugin
                     'category_parent_names',
                     'category_parent_urls'
                 );
+
+                $touchUpdaterSet->add($index, $productRawData[self::TOUCH_EXPORTER_ID]);
             }
         }
 

--- a/src/Pyz/Zed/Collector/Business/Storage/RedirectCollector.php
+++ b/src/Pyz/Zed/Collector/Business/Storage/RedirectCollector.php
@@ -56,6 +56,10 @@ class RedirectCollector extends AbstractPropelCollectorPlugin
         $baseQuery->withColumn(SpyUrlTableMap::COL_URL, self::KEY_FROM_URL);
         $baseQuery->withColumn(SpyRedirectTableMap::COL_STATUS, self::KEY_STATUS);
         $baseQuery->withColumn(SpyRedirectTableMap::COL_TO_URL, self::KEY_TO_URL);
+        $baseQuery->withColumn(
+            SpyTouchTableMap::COL_ID_TOUCH,
+            self::TOUCH_EXPORTER_ID
+        );
 
         return $baseQuery;
     }
@@ -78,6 +82,8 @@ class RedirectCollector extends AbstractPropelCollectorPlugin
                 self::KEY_STATUS => $redirect[self::KEY_STATUS],
                 self::KEY_ID => $redirect[self::KEY_ID],
             ];
+
+            $touchUpdaterSet->add($redirectKey, $redirect[self::TOUCH_EXPORTER_ID]);
         }
 
         return $processedResultSet;

--- a/src/Pyz/Zed/Collector/Business/Storage/TranslationCollector.php
+++ b/src/Pyz/Zed/Collector/Business/Storage/TranslationCollector.php
@@ -56,6 +56,10 @@ class TranslationCollector extends AbstractPropelCollectorPlugin
 
         $baseQuery->withColumn(SpyGlossaryTranslationTableMap::COL_VALUE, 'translation_value');
         $baseQuery->withColumn(SpyGlossaryKeyTableMap::COL_KEY, 'translation_key');
+        $baseQuery->withColumn(
+            SpyTouchTableMap::COL_ID_TOUCH,
+            self::TOUCH_EXPORTER_ID
+        );
 
         return $baseQuery;
     }
@@ -74,6 +78,7 @@ class TranslationCollector extends AbstractPropelCollectorPlugin
         foreach ($resultSet as $index => $translation) {
             $key = $this->generateKey($translation['translation_key'], $locale->getLocaleName());
             $processedResultSet[$key] = $translation['translation_value'];
+            $touchUpdaterSet->add($key, $translation[self::TOUCH_EXPORTER_ID]);
         }
 
         return $processedResultSet;

--- a/src/Pyz/Zed/Collector/Business/Storage/UrlCollector.php
+++ b/src/Pyz/Zed/Collector/Business/Storage/UrlCollector.php
@@ -52,6 +52,11 @@ class UrlCollector extends AbstractPropelCollectorPlugin
 
         $baseQuery->withColumn(SpyUrlTableMap::COL_URL, 'url');
 
+        $baseQuery->withColumn(
+            SpyTouchTableMap::COL_ID_TOUCH,
+            self::TOUCH_EXPORTER_ID
+        );
+
         return $baseQuery;
     }
 
@@ -104,6 +109,8 @@ class UrlCollector extends AbstractPropelCollectorPlugin
                 'reference_key' => $referenceKey,
                 'type' => $resourceArguments['resourceType'],
             ];
+
+            $touchUpdaterSet->add($indexKey, $url[self::TOUCH_EXPORTER_ID]);
         }
 
         return $processedResultSet;


### PR DESCRIPTION
Demoshop collectors don't update spy_storage and spy_search tables
- [x] License checked
- [x] Integration check passed
- [x] Run CS-Fixer
- [ ] Documentation
- [ ] Backward compatible breaks
- [ ] Deprecations

Ticket Numbers: SP-167
Sub PR's:
Reviewed by:
Develop ready approved by:
