### PR TITLE
SP-168: fix bug when shipment address was copied over even when it wa…

### DIFF
--- a/src/Pyz/Yves/Checkout/Communication/Controller/CheckoutController.php
+++ b/src/Pyz/Yves/Checkout/Communication/Controller/CheckoutController.php
@@ -184,8 +184,8 @@ class CheckoutController extends AbstractController
      */
     protected function setShippingAddress(CheckoutRequestTransfer $checkoutRequestTransfer)
     {
-        $shippingAddresTransfer = $checkoutRequestTransfer->getShippingAddress();
-        if ($shippingAddresTransfer->getAddress1() === null) {
+        $shippingAddressTransfer = $checkoutRequestTransfer->getShippingAddress();
+        if ($shippingAddressTransfer->getAddress1() === null) {
             $checkoutRequestTransfer->setShippingAddress($checkoutRequestTransfer->getBillingAddress());
         }
     }


### PR DESCRIPTION
Fixed issue with shipping method were copied even when it's filled in form.
- [x] License checked
- [ ] Integration check passed
- [ ] Run CS-Fixer
- [ ] Documentation
- [ ] Backward compatible breaks
- [ ] Deprecations

Ticket Numbers: https://spryker.atlassian.net/browse/SP-168
Sub PR's:
Reviewed by:
Develop ready approved by:
