### PR TITLE
Facet config fix

### DIFF
--- a/src/Pyz/Client/Catalog/CatalogFactory.php
+++ b/src/Pyz/Client/Catalog/CatalogFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the Spryker Demoshop.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Pyz\Client\Catalog;
+
+use Pyz\Client\Catalog\Model\FacetConfig;
+use Spryker\Client\Catalog\CatalogFactory as SprykerCatalogFactory;
+
+class CatalogFactory extends SprykerCatalogFactory
+{
+
+    /**
+     * @return \Pyz\Client\Catalog\Model\FacetConfig
+     */
+    public function createFacetConfig()
+    {
+        return new FacetConfig();
+    }
+
+}


### PR DESCRIPTION
Project level FacetConfig wasn't used since we removed config locating.

Ticket number: https://github.com/spryker/spryker/issues/1491
