### PR TITLE
If address is billing and shipping add both labels to row

### DIFF
--- a/src/Pyz/Yves/Customer/Controller/AddressController.php
+++ b/src/Pyz/Yves/Customer/Controller/AddressController.php
@@ -155,20 +155,15 @@ class AddressController extends AbstractCustomerController
         }
 
         foreach ($addressesTransfer->getAddresses() as $addressTransfer) {
-            $other = true;
             if ((int)$addressTransfer->getIdCustomerAddress() === (int)$customerTransfer->getDefaultBillingAddress()) {
-                $responseData[self::KEY_DEFAULT_BILLING_ADDRESS] = $addressTransfer;
-                $other = false;
+                $addressTransfer->setIsDefaultBilling(true);
             }
 
             if ((int)$addressTransfer->getIdCustomerAddress() === (int)$customerTransfer->getDefaultShippingAddress()) {
-                $responseData[self::KEY_DEFAULT_SHIPPING_ADDRESS] = $addressTransfer;
-                $other = false;
+                $addressTransfer->setIsDefaultShipping(true);
             }
 
-            if ($other) {
-                $responseData[self::KEY_ADDRESSES][] = $addressTransfer;
-            }
+            $responseData[self::KEY_ADDRESSES][] = $addressTransfer;
         }
 
         return $responseData;

--- a/src/Pyz/Yves/Customer/Theme/demoshop/address/index.twig
+++ b/src/Pyz/Yves/Customer/Theme/demoshop/address/index.twig
@@ -1,6 +1,6 @@
 {% extends "@application/layout/layout.twig" %}
 
-{% macro row(address, type) %}
+{% macro row(address) %}
     <tr>
         <td>{{ address.getFirstName() }} {{ address.getLastName() }}</td>
         <td>
@@ -12,7 +12,10 @@
             {% endspaceless %}
         </td>
         <td class="text-right">
-            {% if type is not empty %}<span class="label label-info">{{ type }}</span>{% endif %}
+
+            {% if address.getIsDefaultShipping %}<span class="label label-info">shipping</span>{% endif %}
+            {% if address.getIsDefaultBilling %}<span class="label label-info">billing</span>{% endif %}
+
             <a href="{{ url('customer/address/update', {'id': address.getIdCustomerAddress()}) }}" class="edit-data">
                 {{ "customer.profile.address.edit" | trans }}
             </a>
@@ -38,13 +41,6 @@
                     </div>
                     <div class="panel-body">
                         <table class="table border-bottom">
-                            {% if default_billing_address is not null %}
-                                {{ table.row(default_billing_address, 'billing') }}
-                            {% endif %}
-                            {% if default_shipping_address is not null %}
-                                {{ table.row(default_shipping_address, 'shipping') }}
-                            {% endif %}
-
                             {% for address in addresses %}
                                 {{ table.row(address) }}
                             {% endfor %}


### PR DESCRIPTION
Previously a address marked as billing and shipping generated two address rows in the Customer Address view.

This let people think when the add one of the addresses only this address is changed not both. In fact there is only one address. When we display two rows people might think they are stored separately and they can edit both separately.

Now the address is only rendered once with both labels

Ticket: https://github.com/spryker/spryker/issues/1526
