### PR TITLE
Do not declare core include for codeception.

### DIFF
--- a/codeception.yml
+++ b/codeception.yml
@@ -1,8 +1,5 @@
 actor: Tester
 
-include:
-- vendor/spryker/*
-
 paths:
     tests: tests
     log: tests/_output


### PR DESCRIPTION
@lazystar says this is needed for project scope.
@stereomon Can you confirm that this is a good change for demoshop only?