### PR TITLE
Fix composer update to always produce https instead of ssh URLs.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -247,7 +247,8 @@
       "PhantomInstaller\\Installer::installPhantomJS"
     ],
     "post-update-cmd": [
-      "PhantomInstaller\\Installer::installPhantomJS"
+      "PhantomInstaller\\Installer::installPhantomJS",
+      "Install\\ComposerAdjuster::assertDemoshopGitUrls"
     ]
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -8,19 +8,23 @@
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.33.3",
+            "version": "3.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "2820644f411fa261f126727c1c00de15227b9520"
+                "reference": "df7ddca6872048cc91315c2b4fdb9a57d5fceb84"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/2820644f411fa261f126727c1c00de15227b9520",
-                "reference": "2820644f411fa261f126727c1c00de15227b9520",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/df7ddca6872048cc91315c2b4fdb9a57d5fceb84",
+                "reference": "df7ddca6872048cc91315c2b4fdb9a57d5fceb84",
                 "shasum": ""
             },
             "require": {
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "ext-spl": "*",
                 "guzzlehttp/guzzle": "^5.3.1|^6.2.1",
                 "guzzlehttp/promises": "~1.0",
                 "guzzlehttp/psr7": "^1.4.1",
@@ -33,11 +37,7 @@
                 "behat/behat": "~3.0",
                 "doctrine/cache": "~1.4",
                 "ext-dom": "*",
-                "ext-json": "*",
                 "ext-openssl": "*",
-                "ext-pcre": "*",
-                "ext-simplexml": "*",
-                "ext-spl": "*",
                 "nette/neon": "^2.3",
                 "phpunit/phpunit": "^4.8.35|^5.4.0",
                 "psr/cache": "^1.0"
@@ -84,7 +84,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2017-08-18T18:04:40+00:00"
+            "time": "2017-08-22T18:32:28+00:00"
         },
         {
             "name": "braintree/braintree_php",
@@ -2684,7 +2684,7 @@
             "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "git@github.com:spryker/CartVariant.git",
+                "url": "https://github.com/spryker/CartVariant.git",
                 "reference": "daf6ef9ec0d536c879f188335a8e8d16412c89a6",
                 "mirrors": [
                     {
@@ -9711,7 +9711,7 @@
             "version": "0.1.1",
             "source": {
                 "type": "git",
-                "url": "git@github.com:spryker/rabbit-mq.git",
+                "url": "https://github.com/spryker/rabbit-mq.git",
                 "reference": "8315b6d650378462f0310730f3940776487e04df",
                 "mirrors": [
                     {
@@ -10457,7 +10457,7 @@
             "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "git@github.com:spryker/ShipmentDiscountConnector.git",
+                "url": "https://github.com/spryker/ShipmentDiscountConnector.git",
                 "reference": "ce4193e9fb942fd330321cb3edb6158c4f5645fa",
                 "mirrors": [
                     {
@@ -16599,7 +16599,7 @@
             "version": "0.3.3",
             "source": {
                 "type": "git",
-                "url": "git@github.com:spryker/code-generator.git",
+                "url": "https://github.com/spryker/code-generator.git",
                 "reference": "36275f0ca30c780eca148c0fb62af5ed0abb635d",
                 "mirrors": [
                     {
@@ -16754,7 +16754,7 @@
             "version": "3.2.10",
             "source": {
                 "type": "git",
-                "url": "git@github.com:spryker/Testify.git",
+                "url": "https://github.com/spryker/Testify.git",
                 "reference": "cfc1c46c1a66e05d1ed207c94eec2a7fb792525e",
                 "mirrors": [
                     {

--- a/src/Install/ComposerAdjuster.php
+++ b/src/Install/ComposerAdjuster.php
@@ -1,0 +1,52 @@
+<?php
+namespace Install;
+
+/**
+ * This fixes a composer issue of not respecting the github-protocols option.
+ * We need to manually assert that our demoshop uses https URLs instead of ssh ones.
+ *
+ * Projects can safely remove this file and the composer post-update-cmd hook.
+ */
+class ComposerAdjuster
+{
+
+    /**
+     * @return void
+     */
+    public static function assertDemoshopGitUrls()
+    {
+        $composerJson = file_get_contents(dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR . 'composer.json');
+        preg_match('/"github-protocols": \[(.+)\]/', $composerJson, $matches);
+        if (!$matches) {
+            return;
+        }
+
+        $protocols = explode(',', $matches[1]);
+        foreach ($protocols as $k => $v) {
+            $protocols[$k] = trim(str_replace('"', '', $v));
+        }
+
+        if ($protocols !== ['https']) {
+            return;
+        }
+
+        static::assertHttps();
+    }
+
+    /**
+     * @return void
+     */
+    protected static function assertHttps()
+    {
+        $composerLockFile = dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR . 'composer.lock';
+        $composerLock = file_get_contents($composerLockFile);
+
+        $composerLockUpdated = str_replace('git@github.com:spryker/', 'https://github.com/spryker/', $composerLock);
+        if ($composerLockUpdated === $composerLock) {
+            return;
+        }
+
+        file_put_contents($composerLockFile, $composerLockUpdated);
+    }
+
+}


### PR DESCRIPTION
Only for us internally to not cause problems for (new) customers checking out our demoshop. 
Projects can remove if desired - or adjust their github-protocols option.